### PR TITLE
Improve Claude Code workflow with security guard and CLAUDE.md

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,27 +3,24 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body || '', '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,19 +29,21 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@04f907ba2a4c77706a56b4078c682d250716cc0c # v1.0.72
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          allowed_tools: "Read,Write,Edit,Glob,Grep,Bash(cargo:*),Bash(python:*),Bash(python3:*),Bash(pip:*),Bash(pip3:*),Bash(git:*),Bash(gh:*),WebFetch,WebSearch,Skill,EnterPlanMode,ExitPlanMode,Agent"
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          plugin_marketplaces: |
+            https://github.com/UtakataKyosui/C2Lab.git
 
+          plugins: |
+            jj-vcs-workflow@utakata-plugins
+            rust@utakata-plugins
+            tdd-enforce@utakata-plugins
+            wasm-optimizer@utakata-plugins
+            moon-proto@utakata-plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# OpenModels - Claude Code 設定
+
+## プロジェクト概要
+
+OpenAPI スキーマから各言語のコードを生成する CLI ツール。
+現在は Python で実装されているが、Rust への書き換えを予定。
+SeaORM (Rust) のフィクスチャ生成も含む。
+
+## 開発方針
+
+- TDD 必須: テストを先に書いてから実装（`~/.claude/CLAUDE.md` のグローバル設定参照）
+- カバレッジ 85% 以上を常に維持
+- Python 実装中は 3.11 / 3.12 両対応
+
+## テスト実行（現在: Python）
+
+```bash
+python -m coverage run --source=openmodels,scripts -m unittest discover -s tests
+python -m coverage report -m --fail-under=85
+```
+
+## テスト実行（Rust 移行後）
+
+```bash
+cargo test
+```
+
+## コード変更時の注意
+
+- `examples/` の OpenAPI スキーマを変更した場合は `python scripts/validate_examples.py` を実行
+- SeaORM フィクスチャを変更した場合は `python scripts/check_seaorm_fixture.py` で Rust コンパイルチェック


### PR DESCRIPTION
## Summary

- `author_association` ガード追加（OWNER/MEMBER/COLLABORATOR のみ `@claude` 呼び出し可）
- Concurrency 設定追加（同一 Issue での並列実行をキューイングに変更）
- Permissions を write に拡張（contents/pull-requests/issues）
- トリガーを `issue_comment` のみに絞り込み
- `allowed_tools` に Read/Write/Edit/Glob/Grep/Bash 系/Skill/EnterPlanMode/Agent を追加
- Action を `v1.0.72` コミットハッシュ固定に更新
- C2Lab プラグイン追加（rust/tdd-enforce/wasm-optimizer 等）
- `CLAUDE.md` 新規作成（プロジェクト固有の指示）

## Test plan

- [ ] OWNER/MEMBER/COLLABORATOR ユーザーが Issue に `@claude` でコメント → ワークフロー起動を確認
- [ ] 外部ユーザーがコメント → ワークフローがスキップされることを確認
- [ ] 同一 Issue に複数コメント → キューイングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)